### PR TITLE
[Bug] 현재 상태 확인 버그

### DIFF
--- a/StockWatch/StockWatch/Data/Repositories/YahooFinance/StrategyEvaluationRepository.swift
+++ b/StockWatch/StockWatch/Data/Repositories/YahooFinance/StrategyEvaluationRepository.swift
@@ -16,8 +16,11 @@ final class StrategyEvaluationRepository: StrategyEvaluationRepositoryProtocol {
     }
 
     func evaluate(ticker: String, parameters: StrategyParameters) async throws -> StrategySignal {
+        // 거래일 → 캘린더일 변환: 1 거래일 ≈ 1.45 캘린더일 (연간 252 거래일 / 365 캘린더일)
+        // 여유분 20일 추가로 공휴일·주말 편차 보정
+        let daysBack = Int(Double(parameters.requiredTradingDays) * 1.5) + 20
         let dto = try await networkService.request(
-            router: YahooFinanceChartRouter.dailyChart(symbol: ticker),
+            router: YahooFinanceChartRouter.dailyChart(symbol: ticker, daysBack: daysBack),
             model: YahooFinanceChartDTO.self
         )
         let closes = YahooFinanceChartMapper.mapToCloses(dto)

--- a/StockWatch/StockWatch/Domain/Entities/StrategyParameters.swift
+++ b/StockWatch/StockWatch/Domain/Entities/StrategyParameters.swift
@@ -16,6 +16,15 @@ enum StrategyParameters: Equatable, Hashable {
 
 extension StrategyParameters {
 
+    /// 기술 지표 계산에 필요한 최소 거래일 수
+    var requiredTradingDays: Int {
+        switch self {
+        case let .sma(shortPeriod, longPeriod): return max(shortPeriod, longPeriod)
+        case let .ema(shortPeriod, longPeriod): return max(shortPeriod, longPeriod)
+        case let .rsi(period, _, _): return period + 1
+        }
+    }
+
     /// 파라미터의 전략 ID
     var strategyId: String {
         switch self {


### PR DESCRIPTION
# 📌 이슈번호
- #57 

# 📌 구현/추가 사항
- 필요한 데이터가 부족한 게 아니라, 유효성 검사를 통과하지 못했던 것
- 실제 일수와 거래일은 다른 문제 때문에 버그 발생중이었음
- 사용자가 장기 이평선 일수 입력 시 거래일로 변환하여 유효성 검증 실시