### PR TITLE
[New Feature] 워치리스트 기능 추가

### DIFF
--- a/StockWatch/StockWatch/Core/Extensions/String+TickerCurrency.swift
+++ b/StockWatch/StockWatch/Core/Extensions/String+TickerCurrency.swift
@@ -15,4 +15,9 @@ extension String {
         if hasSuffix(".HNX") || hasSuffix(".HCM") { return "VND" }
         return "USD"
     }
+
+    /// 국내 주식 여부 (KOSPI: .KS, KOSDAQ: .KQ, KONEX: .KX)
+    var isDomesticTicker: Bool {
+        hasSuffix(".KS") || hasSuffix(".KQ") || hasSuffix(".KX")
+    }
 }

--- a/StockWatch/StockWatch/Data/Mappers/YahooFinance/YahooFinanceExchangeRateMapper.swift
+++ b/StockWatch/StockWatch/Data/Mappers/YahooFinance/YahooFinanceExchangeRateMapper.swift
@@ -1,0 +1,12 @@
+//
+//  YahooFinanceExchangeRateMapper.swift
+//  StockWatch
+//
+
+/// Yahoo Finance Quote DTO에서 환율 값을 추출하는 Mapper
+/// 기존 YahooFinanceQuoteDTO를 재사용한다 (같은 /v8/finance/chart 엔드포인트).
+enum YahooFinanceExchangeRateMapper {
+    static func map(currency: String, dto: YahooFinanceQuoteDTO) -> Double {
+        dto.chart.result?.first?.meta.regularMarketPrice ?? 0.0
+    }
+}

--- a/StockWatch/StockWatch/Data/Network/YahooFinance/Router/YahooFinanceExchangeRateRouter.swift
+++ b/StockWatch/StockWatch/Data/Network/YahooFinance/Router/YahooFinanceExchangeRateRouter.swift
@@ -1,0 +1,22 @@
+//
+//  YahooFinanceExchangeRateRouter.swift
+//  StockWatch
+//
+
+import Alamofire
+
+/// Yahoo Finance 환율 조회 Router
+/// symbol 예: "KRW=X" → 1 USD = X KRW
+struct YahooFinanceExchangeRateRouter: NetworkRouter {
+    let currency: String
+
+    var apiService: APIService { .yahooFinance }
+    var path: String { "/v8/finance/chart/\(currency)=X" }
+    var method: HTTPMethod { .get }
+    var headers: [String: String]? {
+        ["User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"]
+    }
+    var parameters: [String: Any]? {
+        ["range": "1d", "interval": "1d"]
+    }
+}

--- a/StockWatch/StockWatch/Data/Repositories/YahooFinance/CandlestickRepository.swift
+++ b/StockWatch/StockWatch/Data/Repositories/YahooFinance/CandlestickRepository.swift
@@ -31,4 +31,12 @@ final class CandlestickRepository: CandlestickRepositoryProtocol {
         )
         return mapper.map(dto: dto, ticker: ticker)
     }
+
+    func fetchCandlesticks(ticker: String, range: String, interval: String) async throws -> CandlestickData {
+        let dto = try await networkService.request(
+            router: YahooFinanceCandlestickRouter(symbol: ticker, range: range, interval: interval),
+            model: YahooFinanceCandlestickDTO.self
+        )
+        return mapper.map(dto: dto, ticker: ticker)
+    }
 }

--- a/StockWatch/StockWatch/Data/Repositories/YahooFinance/ExchangeRateRepository.swift
+++ b/StockWatch/StockWatch/Data/Repositories/YahooFinance/ExchangeRateRepository.swift
@@ -1,0 +1,37 @@
+//
+//  ExchangeRateRepository.swift
+//  StockWatch
+//
+
+import Foundation
+
+/// 환율 도메인 Repository 구현체
+/// Yahoo Finance API를 통해 USD 기준 환율을 조회한다.
+final class ExchangeRateRepository: ExchangeRateRepositoryProtocol {
+    private let networkService: NetworkServiceProtocol
+
+    init(networkService: NetworkServiceProtocol = NetworkService()) {
+        self.networkService = networkService
+    }
+
+    func fetchRates(currencies: [String]) async throws -> [String: Double] {
+        try await withThrowingTaskGroup(of: (String, Double).self) { group in
+            for currency in currencies {
+                group.addTask {
+                    let dto = try await self.networkService.request(
+                        router: YahooFinanceExchangeRateRouter(currency: currency),
+                        model: YahooFinanceQuoteDTO.self
+                    )
+                    let rate = YahooFinanceExchangeRateMapper.map(currency: currency, dto: dto)
+                    return (currency, rate)
+                }
+            }
+
+            var rates: [String: Double] = [:]
+            for try await (currency, rate) in group {
+                rates[currency] = rate
+            }
+            return rates
+        }
+    }
+}

--- a/StockWatch/StockWatch/Domain/Entities/ExchangeRate.swift
+++ b/StockWatch/StockWatch/Domain/Entities/ExchangeRate.swift
@@ -1,0 +1,11 @@
+//
+//  ExchangeRate.swift
+//  StockWatch
+//
+
+/// 환율 정보를 나타내는 경량 도메인 엔티티
+/// rateToUSD: 1 USD = rateToUSD 해당 통화 (예: KRW이면 1380.0)
+struct ExchangeRate: Equatable {
+    let currency: String
+    let rateToUSD: Double
+}

--- a/StockWatch/StockWatch/Domain/Entities/SparklineData.swift
+++ b/StockWatch/StockWatch/Domain/Entities/SparklineData.swift
@@ -1,0 +1,10 @@
+//
+//  SparklineData.swift
+//  StockWatch
+//
+
+/// 스파크라인 차트에 사용할 종가 데이터
+struct SparklineData: Equatable {
+    let ticker: String
+    let closePrices: [Double]
+}

--- a/StockWatch/StockWatch/Domain/Protocol/CandlestickRepositoryProtocol.swift
+++ b/StockWatch/StockWatch/Domain/Protocol/CandlestickRepositoryProtocol.swift
@@ -6,4 +6,5 @@
 protocol CandlestickRepositoryProtocol {
     func fetchCandlesticks(ticker: String, period: ChartPeriod) async throws -> CandlestickData
     func fetchCandlesticks(ticker: String, interval: String, period1: Int, period2: Int) async throws -> CandlestickData
+    func fetchCandlesticks(ticker: String, range: String, interval: String) async throws -> CandlestickData
 }

--- a/StockWatch/StockWatch/Domain/Protocol/ExchangeRateRepositoryProtocol.swift
+++ b/StockWatch/StockWatch/Domain/Protocol/ExchangeRateRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ExchangeRateRepositoryProtocol.swift
+//  StockWatch
+//
+
+/// 환율 도메인 Repository 인터페이스
+/// Data 레이어에서 구현하며, Domain/Presentation은 이 Protocol에만 의존한다.
+protocol ExchangeRateRepositoryProtocol {
+    /// 주어진 통화 목록에 대해 USD 기준 환율을 조회한다.
+    /// - Parameter currencies: 통화 코드 배열 (예: ["KRW", "JPY"])
+    /// - Returns: [통화코드: 1 USD 대비 환율] (예: ["KRW": 1380.0, "JPY": 155.0])
+    func fetchRates(currencies: [String]) async throws -> [String: Double]
+}

--- a/StockWatch/StockWatch/Domain/UseCases/FetchExchangeRateUseCase.swift
+++ b/StockWatch/StockWatch/Domain/UseCases/FetchExchangeRateUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchExchangeRateUseCase.swift
+//  StockWatch
+//
+
+/// 환율 조회 UseCase 구현체
+/// USD는 항상 1.0으로 포함하고, 나머지 통화는 Repository를 통해 조회한다.
+final class FetchExchangeRateUseCase: FetchExchangeRateUseCaseProtocol {
+
+    private let repository: ExchangeRateRepositoryProtocol
+
+    init(repository: ExchangeRateRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(currencies: [String]) async throws -> [String: Double] {
+        let nonUSD = currencies.filter { $0 != "USD" }
+        var rates: [String: Double] = ["USD": 1.0]
+        if !nonUSD.isEmpty {
+            let fetched = try await repository.fetchRates(currencies: nonUSD)
+            rates.merge(fetched) { _, new in new }
+        }
+        return rates
+    }
+}

--- a/StockWatch/StockWatch/Domain/UseCases/FetchExchangeRateUseCaseProtocol.swift
+++ b/StockWatch/StockWatch/Domain/UseCases/FetchExchangeRateUseCaseProtocol.swift
@@ -1,0 +1,11 @@
+//
+//  FetchExchangeRateUseCaseProtocol.swift
+//  StockWatch
+//
+
+/// 환율 조회 UseCase 인터페이스
+protocol FetchExchangeRateUseCaseProtocol {
+    /// 주어진 통화 목록에 대해 USD 기준 환율을 조회한다.
+    /// USD는 자동으로 1.0으로 포함된다.
+    func execute(currencies: [String]) async throws -> [String: Double]
+}

--- a/StockWatch/StockWatch/Domain/UseCases/FetchSparklineUseCase.swift
+++ b/StockWatch/StockWatch/Domain/UseCases/FetchSparklineUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  FetchSparklineUseCase.swift
+//  StockWatch
+//
+
+/// 스파크라인 데이터 조회 UseCase 구현체
+final class FetchSparklineUseCase: FetchSparklineUseCaseProtocol {
+
+    private let repository: CandlestickRepositoryProtocol
+
+    init(repository: CandlestickRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(ticker: String) async throws -> SparklineData {
+        guard !ticker.isEmpty else {
+            throw FetchSparklineError.emptyTicker
+        }
+        let candlestickData = try await repository.fetchCandlesticks(
+            ticker: ticker,
+            range: "5d",
+            interval: "30m"
+        )
+        let closePrices = candlestickData.candles.map(\.close)
+        return SparklineData(ticker: ticker, closePrices: closePrices)
+    }
+}
+
+enum FetchSparklineError: Error {
+    case emptyTicker
+}

--- a/StockWatch/StockWatch/Domain/UseCases/FetchSparklineUseCaseProtocol.swift
+++ b/StockWatch/StockWatch/Domain/UseCases/FetchSparklineUseCaseProtocol.swift
@@ -1,0 +1,9 @@
+//
+//  FetchSparklineUseCaseProtocol.swift
+//  StockWatch
+//
+
+/// 스파크라인 데이터 조회 UseCase 인터페이스
+protocol FetchSparklineUseCaseProtocol {
+    func execute(ticker: String) async throws -> SparklineData
+}

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Intent/WatchListIntent.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Intent/WatchListIntent.swift
@@ -49,4 +49,6 @@ enum WatchListIntent {
     case removeFavoriteWithUndo(ticker: String)
     /// 토스트 "되돌리기" 탭 → 관심 목록 복원
     case undoRemoveFavorite
+    /// 정렬 기준 토글 (같은 기준: asc→desc→none, 다른 기준: asc)
+    case toggleSort(WatchListSortCriteria)
 }

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Intent/WatchListIntent.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Intent/WatchListIntent.swift
@@ -51,4 +51,6 @@ enum WatchListIntent {
     case undoRemoveFavorite
     /// 정렬 기준 토글 (같은 기준: asc→desc→none, 다른 기준: asc)
     case toggleSort(WatchListSortCriteria)
+    /// 시장 필터 선택 (전체/국내주식/해외주식)
+    case selectMarketFilter(WatchListMarketFilter)
 }

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
@@ -5,6 +5,19 @@
 
 import Foundation
 
+/// 정렬 기준
+enum WatchListSortCriteria: Equatable {
+    case name
+    case price
+    case changePercent
+}
+
+/// 정렬 방향
+enum WatchListSortDirection: Equatable {
+    case ascending
+    case descending
+}
+
 /// 되돌리기를 위한 삭제 전 즐겨찾기 정보
 struct WatchListUndoFavoriteInfo: Equatable {
     let ticker: String
@@ -56,6 +69,11 @@ struct WatchListState {
     var toastMessage: String? = nil
     /// 되돌리기용 삭제 정보
     var undoInfo: WatchListUndoFavoriteInfo? = nil
+
+    /// 정렬 기준 (nil이면 정렬 없음 = 추가순)
+    var sortCriteria: WatchListSortCriteria? = nil
+    /// 정렬 방향 (기본 오름차순)
+    var sortDirection: WatchListSortDirection = .ascending
 
     /// 테스트 편의용 이니셜라이저
     init(favorites: [FavoriteItem] = []) {

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
@@ -42,6 +42,9 @@ struct WatchListState {
     var priceData: [String: StockQuote] = [:]
     var isPriceLoading: Bool = false
 
+    /// 티커 → 스파크라인 데이터
+    var sparklineData: [String: SparklineData] = [:]
+
     /// 그룹 탭 드래그 상태
     var draggedGroupId: UUID? = nil
     var dragTargetIndex: Int? = nil

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
@@ -5,6 +5,13 @@
 
 import Foundation
 
+/// 시장 필터
+enum WatchListMarketFilter: String, CaseIterable, Equatable {
+    case all = "전체"
+    case domestic = "국내주식"
+    case overseas = "해외주식"
+}
+
 /// 정렬 기준
 enum WatchListSortCriteria: Equatable {
     case name
@@ -77,6 +84,9 @@ struct WatchListState {
 
     /// 환율 데이터 (통화코드 → 1 USD 대비 환율, 예: ["KRW": 1380.0])
     var exchangeRates: [String: Double] = [:]
+
+    /// 시장 필터 (전체/국내주식/해외주식)
+    var marketFilter: WatchListMarketFilter = .all
 
     /// 테스트 편의용 이니셜라이저
     init(favorites: [FavoriteItem] = []) {

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/State/WatchListState.swift
@@ -75,6 +75,9 @@ struct WatchListState {
     /// 정렬 방향 (기본 오름차순)
     var sortDirection: WatchListSortDirection = .ascending
 
+    /// 환율 데이터 (통화코드 → 1 USD 대비 환율, 예: ["KRW": 1380.0])
+    var exchangeRates: [String: Double] = [:]
+
     /// 테스트 편의용 이니셜라이저
     init(favorites: [FavoriteItem] = []) {
         self.favorites = favorites

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
@@ -173,19 +173,21 @@ final class WatchListStore: ObservableObject {
 private extension WatchListStore {
 
     func toggleSort(_ criteria: WatchListSortCriteria) {
+        // 등락률은 내림차순(변동 큰 종목)부터 시작, 나머지는 오름차순부터 시작
+        let defaultDirection: WatchListSortDirection = criteria == .changePercent ? .descending : .ascending
+
         if state.sortCriteria == criteria {
-            // 같은 컬럼: asc → desc → none
-            switch state.sortDirection {
-            case .ascending:
-                state.sortDirection = .descending
-            case .descending:
+            // 같은 컬럼: 기본방향 → 반대방향 → none
+            if state.sortDirection == defaultDirection {
+                state.sortDirection = defaultDirection == .ascending ? .descending : .ascending
+            } else {
                 state.sortCriteria = nil
                 state.sortDirection = .ascending
             }
         } else {
-            // 다른 컬럼: 오름차순으로 시작
+            // 다른 컬럼: 해당 기준의 기본방향으로 시작
             state.sortCriteria = criteria
-            state.sortDirection = .ascending
+            state.sortDirection = defaultDirection
         }
     }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
@@ -22,6 +22,7 @@ final class WatchListStore: ObservableObject {
     private let fetchGroupIdsForTickerUseCase: FetchGroupIdsForTickerUseCaseProtocol
     private let updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCaseProtocol
     private let fetchSparklineUseCase: FetchSparklineUseCaseProtocol
+    private let fetchExchangeRateUseCase: FetchExchangeRateUseCaseProtocol
     private var toastDismissTask: Task<Void, Never>?
 
     // MARK: - Init
@@ -36,6 +37,7 @@ final class WatchListStore: ObservableObject {
         fetchGroupIdsForTickerUseCase: FetchGroupIdsForTickerUseCaseProtocol,
         updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCaseProtocol,
         fetchSparklineUseCase: FetchSparklineUseCaseProtocol,
+        fetchExchangeRateUseCase: FetchExchangeRateUseCaseProtocol,
         state: WatchListState = WatchListState()
     ) {
         self.state = state
@@ -48,6 +50,7 @@ final class WatchListStore: ObservableObject {
         self.fetchGroupIdsForTickerUseCase = fetchGroupIdsForTickerUseCase
         self.updateFavoriteGroupsUseCase = updateFavoriteGroupsUseCase
         self.fetchSparklineUseCase = fetchSparklineUseCase
+        self.fetchExchangeRateUseCase = fetchExchangeRateUseCase
     }
 
     // MARK: - Action
@@ -132,10 +135,12 @@ final class WatchListStore: ObservableObject {
                     ? nameA.localizedCompare(nameB) == .orderedAscending
                     : nameA.localizedCompare(nameB) == .orderedDescending
             case .price:
-                let priceA = state.priceData[a.ticker]?.currentPrice
-                let priceB = state.priceData[b.ticker]?.currentPrice
-                guard let pA = priceA else { return false }
-                guard let pB = priceB else { return true }
+                let quoteA = state.priceData[a.ticker]
+                let quoteB = state.priceData[b.ticker]
+                guard let qA = quoteA else { return false }
+                guard let qB = quoteB else { return true }
+                let pA = priceInUSD(qA.currentPrice, currency: qA.currency)
+                let pB = priceInUSD(qB.currentPrice, currency: qB.currency)
                 return ascending ? pA < pB : pA > pB
             case .changePercent:
                 let changeA = state.priceData[a.ticker]?.priceChangePercent
@@ -145,6 +150,13 @@ final class WatchListStore: ObservableObject {
                 return ascending ? cA < cB : cA > cB
             }
         }
+    }
+
+    /// 환율을 적용하여 USD 기준 가격으로 변환한다.
+    /// 환율 데이터가 없으면 원래 가격을 그대로 반환한다 (fallback).
+    private func priceInUSD(_ price: Double, currency: String) -> Double {
+        guard let rate = state.exchangeRates[currency], rate > 0 else { return price }
+        return price / rate
     }
 
     /// 표시 이름: 한국어명 → 영어명 → 티커 fallback
@@ -335,6 +347,16 @@ private extension WatchListStore {
             }
             state.priceData = result
             state.isPriceLoading = false
+            loadExchangeRates()
+        }
+    }
+
+    func loadExchangeRates() {
+        let currencies = Set(state.priceData.values.map(\.currency))
+        guard !currencies.isEmpty else { return }
+        Task {
+            let rates = try? await fetchExchangeRateUseCase.execute(currencies: Array(currencies))
+            if let rates { state.exchangeRates = rates }
         }
     }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
@@ -112,7 +112,46 @@ final class WatchListStore: ObservableObject {
             Task { await removeFavoriteWithUndo(ticker: ticker) }
         case .undoRemoveFavorite:
             Task { await undoRemoveFavorite() }
+        case .toggleSort(let criteria):
+            toggleSort(criteria)
         }
+    }
+
+    // MARK: - Sorted Favorites
+
+    /// 정렬 기준이 있으면 정렬된 배열, 없으면 원본(추가순) 반환
+    var sortedFavorites: [FavoriteItem] {
+        guard let criteria = state.sortCriteria else { return state.favorites }
+        let ascending = state.sortDirection == .ascending
+        return state.favorites.sorted { a, b in
+            switch criteria {
+            case .name:
+                let nameA = displayName(for: a)
+                let nameB = displayName(for: b)
+                return ascending
+                    ? nameA.localizedCompare(nameB) == .orderedAscending
+                    : nameA.localizedCompare(nameB) == .orderedDescending
+            case .price:
+                let priceA = state.priceData[a.ticker]?.currentPrice
+                let priceB = state.priceData[b.ticker]?.currentPrice
+                guard let pA = priceA else { return false }
+                guard let pB = priceB else { return true }
+                return ascending ? pA < pB : pA > pB
+            case .changePercent:
+                let changeA = state.priceData[a.ticker]?.priceChangePercent
+                let changeB = state.priceData[b.ticker]?.priceChangePercent
+                guard let cA = changeA else { return false }
+                guard let cB = changeB else { return true }
+                return ascending ? cA < cB : cA > cB
+            }
+        }
+    }
+
+    /// 표시 이름: 한국어명 → 영어명 → 티커 fallback
+    private func displayName(for item: FavoriteItem) -> String {
+        KoreanStockDictionary.shared.entries
+            .first(where: { $0.ticker == item.ticker })?.nameKo
+            ?? (item.companyName.isEmpty ? item.ticker : item.companyName)
     }
 
     // MARK: - Navigation Binding
@@ -132,6 +171,23 @@ final class WatchListStore: ObservableObject {
 // MARK: - Private
 
 private extension WatchListStore {
+
+    func toggleSort(_ criteria: WatchListSortCriteria) {
+        if state.sortCriteria == criteria {
+            // 같은 컬럼: asc → desc → none
+            switch state.sortDirection {
+            case .ascending:
+                state.sortDirection = .descending
+            case .descending:
+                state.sortCriteria = nil
+                state.sortDirection = .ascending
+            }
+        } else {
+            // 다른 컬럼: 오름차순으로 시작
+            state.sortCriteria = criteria
+            state.sortDirection = .ascending
+        }
+    }
 
     func loadFavorites() {
         state.isLoading = true

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
@@ -21,6 +21,7 @@ final class WatchListStore: ObservableObject {
     private let fetchStockQuoteUseCase: FetchStockQuoteUseCaseProtocol
     private let fetchGroupIdsForTickerUseCase: FetchGroupIdsForTickerUseCaseProtocol
     private let updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCaseProtocol
+    private let fetchSparklineUseCase: FetchSparklineUseCaseProtocol
     private var toastDismissTask: Task<Void, Never>?
 
     // MARK: - Init
@@ -34,6 +35,7 @@ final class WatchListStore: ObservableObject {
         fetchStockQuoteUseCase: FetchStockQuoteUseCaseProtocol,
         fetchGroupIdsForTickerUseCase: FetchGroupIdsForTickerUseCaseProtocol,
         updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCaseProtocol,
+        fetchSparklineUseCase: FetchSparklineUseCaseProtocol,
         state: WatchListState = WatchListState()
     ) {
         self.state = state
@@ -45,6 +47,7 @@ final class WatchListStore: ObservableObject {
         self.fetchStockQuoteUseCase = fetchStockQuoteUseCase
         self.fetchGroupIdsForTickerUseCase = fetchGroupIdsForTickerUseCase
         self.updateFavoriteGroupsUseCase = updateFavoriteGroupsUseCase
+        self.fetchSparklineUseCase = fetchSparklineUseCase
     }
 
     // MARK: - Action
@@ -147,7 +150,9 @@ private extension WatchListStore {
             let groupId = state.dbGroups[index].id
             state.favorites = await fetchFavoritesByGroupUseCase.execute(groupId: groupId)
             state.isLoading = false
-            loadPrices(for: state.favorites.map(\.ticker))
+            let tickers = state.favorites.map(\.ticker)
+            loadPrices(for: tickers)
+            loadSparklines(for: tickers)
         }
     }
 
@@ -272,6 +277,25 @@ private extension WatchListStore {
             }
             state.priceData = result
             state.isPriceLoading = false
+        }
+    }
+
+    func loadSparklines(for tickers: [String]) {
+        guard !tickers.isEmpty else { return }
+        Task {
+            var result: [String: SparklineData] = [:]
+            await withTaskGroup(of: (String, SparklineData?).self) { group in
+                for ticker in tickers {
+                    group.addTask {
+                        let data = try? await self.fetchSparklineUseCase.execute(ticker: ticker)
+                        return (ticker, data)
+                    }
+                }
+                for await (ticker, data) in group {
+                    if let data { result[ticker] = data }
+                }
+            }
+            state.sparklineData = result
         }
     }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
@@ -124,11 +124,20 @@ final class WatchListStore: ObservableObject {
 
     // MARK: - Sorted Favorites
 
-    /// 정렬 기준이 있으면 정렬된 배열, 없으면 원본(추가순) 반환
+    /// 마켓 필터 적용 후 정렬 기준이 있으면 정렬된 배열, 없으면 원본(추가순) 반환
     var sortedFavorites: [FavoriteItem] {
-        guard let criteria = state.sortCriteria else { return state.favorites }
+        let filtered: [FavoriteItem]
+        switch state.marketFilter {
+        case .all:
+            filtered = state.favorites
+        case .domestic:
+            filtered = state.favorites.filter { $0.ticker.isDomesticTicker }
+        case .overseas:
+            filtered = state.favorites.filter { !$0.ticker.isDomesticTicker }
+        }
+        guard let criteria = state.sortCriteria else { return filtered }
         let ascending = state.sortDirection == .ascending
-        return state.favorites.sorted { a, b in
+        return filtered.sorted { a, b in
             switch criteria {
             case .name:
                 let nameA = displayName(for: a)

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/Store/WatchListStore.swift
@@ -117,6 +117,8 @@ final class WatchListStore: ObservableObject {
             Task { await undoRemoveFavorite() }
         case .toggleSort(let criteria):
             toggleSort(criteria)
+        case .selectMarketFilter(let filter):
+            state.marketFilter = filter
         }
     }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/SparklineView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/SparklineView.swift
@@ -36,7 +36,7 @@ struct SparklineView: View {
                             path.move(to: CGPoint(x: 0, y: y))
                             path.addLine(to: CGPoint(x: geo.size.width, y: y))
                         }
-                        .stroke(lineColor.opacity(0.5), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
+                        .stroke(Color(.systemGray3), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
                     }
                     // 선
                     linePath(points: points)

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/SparklineView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/SparklineView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct SparklineView: View {
     let closePrices: [Double]
     let isPositive: Bool
+    var currentPrice: Double? = nil
 
     private var lineColor: Color {
         isPositive ? Color(hex: "#ef5350") : Color(hex: "#1976d2")
@@ -28,6 +29,15 @@ struct SparklineView: View {
                                 endPoint: .bottom
                             )
                         )
+                    // 현재가 수평 점선
+                    if let price = currentPrice {
+                        let y = currentPriceY(price: price, height: geo.size.height)
+                        Path { path in
+                            path.move(to: CGPoint(x: 0, y: y))
+                            path.addLine(to: CGPoint(x: geo.size.width, y: y))
+                        }
+                        .stroke(lineColor.opacity(0.5), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
+                    }
                     // 선
                     linePath(points: points)
                         .stroke(lineColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
@@ -49,6 +59,16 @@ struct SparklineView: View {
             let y = size.height - (CGFloat((price - minVal) / safeRange) * size.height)
             return CGPoint(x: x, y: y)
         }
+    }
+
+    private func currentPriceY(price: Double, height: CGFloat) -> CGFloat {
+        let minVal = closePrices.min() ?? 0
+        let maxVal = closePrices.max() ?? 1
+        let range = maxVal - minVal
+        let safeRange = range == 0 ? 1.0 : range
+        let normalized = (price - minVal) / safeRange
+        let y = height - CGFloat(normalized) * height
+        return min(max(y, 0), height)
     }
 
     private func linePath(points: [CGPoint]) -> Path {

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/SparklineView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/SparklineView.swift
@@ -1,0 +1,77 @@
+//
+//  SparklineView.swift
+//  StockWatch
+//
+
+import SwiftUI
+
+/// 종가 데이터를 선 + 그라데이션으로 표시하는 스파크라인 차트
+struct SparklineView: View {
+    let closePrices: [Double]
+    let isPositive: Bool
+
+    private var lineColor: Color {
+        isPositive ? Color(hex: "#ef5350") : Color(hex: "#1976d2")
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let points = normalizedPoints(in: geo.size)
+            if points.count >= 2 {
+                ZStack {
+                    // 그라데이션 채움
+                    fillPath(points: points, height: geo.size.height)
+                        .fill(
+                            LinearGradient(
+                                colors: [lineColor.opacity(0.3), lineColor.opacity(0)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                    // 선
+                    linePath(points: points)
+                        .stroke(lineColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+                }
+            }
+        }
+    }
+
+    private func normalizedPoints(in size: CGSize) -> [CGPoint] {
+        guard closePrices.count >= 2 else { return [] }
+        let minVal = closePrices.min() ?? 0
+        let maxVal = closePrices.max() ?? 1
+        let range = maxVal - minVal
+        let safeRange = range == 0 ? 1.0 : range
+        let stepX = size.width / CGFloat(closePrices.count - 1)
+
+        return closePrices.enumerated().map { index, price in
+            let x = CGFloat(index) * stepX
+            let y = size.height - (CGFloat((price - minVal) / safeRange) * size.height)
+            return CGPoint(x: x, y: y)
+        }
+    }
+
+    private func linePath(points: [CGPoint]) -> Path {
+        Path { path in
+            path.move(to: points[0])
+            for point in points.dropFirst() {
+                path.addLine(to: point)
+            }
+        }
+    }
+
+    private func fillPath(points: [CGPoint], height: CGFloat) -> Path {
+        Path { path in
+            path.move(to: points[0])
+            for point in points.dropFirst() {
+                path.addLine(to: point)
+            }
+            // 아래로 닫기
+            if let last = points.last {
+                path.addLine(to: CGPoint(x: last.x, y: height))
+            }
+            path.addLine(to: CGPoint(x: points[0].x, y: height))
+            path.closeSubpath()
+        }
+    }
+}

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -721,7 +721,7 @@ private struct WatchListSortHeaderView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            sortButton(label: "종목", criteria: .name)
+            sortButton(label: sortCriteria == .name ? "가나다 순" : "종목", criteria: .name)
             Spacer()
             sortButton(label: "현재가", criteria: .price)
             Spacer()

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -230,7 +230,12 @@ private struct WatchListContentView: View {
     private var stockList: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(store.state.favorites, id: \.ticker) { item in
+                WatchListSortHeaderView(
+                    sortCriteria: store.state.sortCriteria,
+                    sortDirection: store.state.sortDirection,
+                    onToggle: { store.action(.toggleSort($0)) }
+                )
+                ForEach(store.sortedFavorites, id: \.ticker) { item in
                     WatchListStockRow(
                         item: item,
                         quoteData: store.state.priceData[item.ticker],
@@ -704,6 +709,52 @@ private struct WatchListGroupManageModalView: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
+    }
+}
+
+// MARK: - Sort Header
+
+private struct WatchListSortHeaderView: View {
+    let sortCriteria: WatchListSortCriteria?
+    let sortDirection: WatchListSortDirection
+    let onToggle: (WatchListSortCriteria) -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            sortButton(label: "종목", criteria: .name)
+            Spacer()
+            sortButton(label: "현재가", criteria: .price)
+            Spacer()
+            sortButton(label: "등락", criteria: .changePercent)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+
+    private func sortButton(label: String, criteria: WatchListSortCriteria) -> some View {
+        let isActive = sortCriteria == criteria
+        return Button {
+            onToggle(criteria)
+        } label: {
+            HStack(spacing: 4) {
+                Text(label)
+                    .font(.pretendardMedium(size: 13))
+                sortIcon(isActive: isActive)
+            }
+            .foregroundStyle(isActive ? .blue : .secondary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func sortIcon(isActive: Bool) -> some View {
+        Group {
+            if isActive {
+                Image(systemName: sortDirection == .ascending ? "arrow.up" : "arrow.down")
+            } else {
+                Image(systemName: "chevron.up.chevron.down")
+            }
+        }
+        .font(.system(size: 11, weight: .medium))
     }
 }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -37,7 +37,8 @@ private struct WatchListContentView: View {
             addFavoriteToGroupUseCase: AddFavoriteToGroupUseCase(repository: repository),
             fetchStockQuoteUseCase: FetchStockQuoteUseCase(repository: StockQuoteRepository()),
             fetchGroupIdsForTickerUseCase: FetchGroupIdsForTickerUseCase(repository: repository),
-            updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCase(repository: repository)
+            updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCase(repository: repository),
+            fetchSparklineUseCase: FetchSparklineUseCase(repository: CandlestickRepository())
         ))
     }
 
@@ -233,6 +234,7 @@ private struct WatchListContentView: View {
                     WatchListStockRow(
                         item: item,
                         quoteData: store.state.priceData[item.ticker],
+                        sparklineData: store.state.sparklineData[item.ticker],
                         displayName: displayName(for: item),
                         onTap: { store.action(.selectTicker(item.ticker)) },
                         onRemove: { store.action(.removeFavoriteWithUndo(ticker: item.ticker)) }
@@ -710,6 +712,7 @@ private struct WatchListGroupManageModalView: View {
 private struct WatchListStockRow: View {
     let item: FavoriteItem
     let quoteData: StockQuote?
+    let sparklineData: SparklineData?
     let displayName: String
     let onTap: () -> Void
     let onRemove: () -> Void
@@ -718,6 +721,8 @@ private struct WatchListStockRow: View {
         HStack(spacing: 12) {
             logoView
             nameColumn
+            Spacer()
+            sparklineColumn
             Spacer()
             priceColumn
             heartButton
@@ -773,6 +778,17 @@ private struct WatchListStockRow: View {
             Text(item.ticker)
                 .font(.pretendardCaption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var sparklineColumn: some View {
+        if let sparkline = sparklineData, sparkline.closePrices.count >= 2 {
+            SparklineView(
+                closePrices: sparkline.closePrices,
+                isPositive: (quoteData?.priceChangePercent ?? 0) >= 0
+            )
+            .frame(width: 60, height: 32)
         }
     }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -94,6 +94,17 @@ private struct WatchListContentView: View {
                 .onAppear {
                     store.action(.loadGroups)
                 }
+                .safeAreaInset(edge: .bottom) {
+                    if !store.state.dbGroups.isEmpty {
+                        WatchListMarketFilterBar(
+                            selectedFilter: store.state.marketFilter,
+                            onSelect: { store.action(.selectMarketFilter($0)) }
+                        )
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                        .padding(.bottom, 24)
+                    }
+                }
             }
 
             if isShowingGroupManageModal {
@@ -894,6 +905,41 @@ private struct WatchListAddStockRow: View {
         .padding(.vertical, 12)
         .contentShape(Rectangle())
         .onTapGesture(perform: onTap)
+    }
+}
+
+// MARK: - Market Filter Bar
+
+private struct WatchListMarketFilterBar: View {
+    let selectedFilter: WatchListMarketFilter
+    let onSelect: (WatchListMarketFilter) -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(WatchListMarketFilter.allCases, id: \.self) { filter in
+                Button {
+                    onSelect(filter)
+                } label: {
+                    Text(filter.rawValue)
+                        .font(selectedFilter == filter ? .pretendardBold(size: 14) : .pretendardMedium(size: 14))
+                        .foregroundStyle(selectedFilter == filter ? Color.primary : Color.secondary)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(
+                            Group {
+                                if selectedFilter == filter {
+                                    Capsule()
+                                        .fill(Color(.systemBackground))
+                                        .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
+                                }
+                            }
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(Capsule().fill(Color(.systemGray6)))
     }
 }
 

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -786,7 +786,8 @@ private struct WatchListStockRow: View {
         if let sparkline = sparklineData, sparkline.closePrices.count >= 2 {
             SparklineView(
                 closePrices: sparkline.closePrices,
-                isPositive: (quoteData?.priceChangePercent ?? 0) >= 0
+                isPositive: (quoteData?.priceChangePercent ?? 0) >= 0,
+                currentPrice: quoteData?.currentPrice
             )
             .frame(width: 60, height: 32)
         }

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -38,7 +38,8 @@ private struct WatchListContentView: View {
             fetchStockQuoteUseCase: FetchStockQuoteUseCase(repository: StockQuoteRepository()),
             fetchGroupIdsForTickerUseCase: FetchGroupIdsForTickerUseCase(repository: repository),
             updateFavoriteGroupsUseCase: UpdateFavoriteGroupsUseCase(repository: repository),
-            fetchSparklineUseCase: FetchSparklineUseCase(repository: CandlestickRepository())
+            fetchSparklineUseCase: FetchSparklineUseCase(repository: CandlestickRepository()),
+            fetchExchangeRateUseCase: FetchExchangeRateUseCase(repository: ExchangeRateRepository())
         ))
     }
 

--- a/StockWatch/StockWatchTests/Data/ExchangeRateMapperTests.swift
+++ b/StockWatch/StockWatchTests/Data/ExchangeRateMapperTests.swift
@@ -1,0 +1,69 @@
+//
+//  ExchangeRateMapperTests.swift
+//  StockWatchTests
+//
+
+import XCTest
+@testable import StockWatch
+
+final class ExchangeRateMapperTests: XCTestCase {
+
+    private func makeQuoteDTO(
+        symbol: String = "KRW=X",
+        regularMarketPrice: Double? = 1380.0
+    ) -> YahooFinanceQuoteDTO {
+        YahooFinanceQuoteDTO(
+            chart: .init(
+                result: [
+                    .init(meta: .init(
+                        symbol: symbol,
+                        regularMarketPrice: regularMarketPrice,
+                        previousClose: nil,
+                        regularMarketChangePercent: nil,
+                        chartPreviousClose: nil,
+                        shortName: nil,
+                        longName: nil,
+                        currency: nil
+                    ))
+                ],
+                error: nil
+            )
+        )
+    }
+
+    // 정상 케이스: 유효한 DTO에서 환율 값을 올바르게 추출하는지 검증
+    func test_map_withValidDTO_returnsCorrectRate() {
+        // Given
+        let dto = makeQuoteDTO(regularMarketPrice: 1380.0)
+
+        // When
+        let rate = YahooFinanceExchangeRateMapper.map(currency: "KRW", dto: dto)
+
+        // Then
+        XCTAssertEqual(rate, 1380.0)
+    }
+
+    // regularMarketPrice가 nil인 경우 0.0을 반환하는지 검증
+    func test_map_withNilPrice_returnsZero() {
+        // Given
+        let dto = makeQuoteDTO(regularMarketPrice: nil)
+
+        // When
+        let rate = YahooFinanceExchangeRateMapper.map(currency: "KRW", dto: dto)
+
+        // Then
+        XCTAssertEqual(rate, 0.0)
+    }
+
+    // result가 빈 배열인 경우 0.0을 반환하는지 검증
+    func test_map_withEmptyResult_returnsZero() {
+        // Given
+        let dto = YahooFinanceQuoteDTO(chart: .init(result: [], error: nil))
+
+        // When
+        let rate = YahooFinanceExchangeRateMapper.map(currency: "KRW", dto: dto)
+
+        // Then
+        XCTAssertEqual(rate, 0.0)
+    }
+}

--- a/StockWatch/StockWatchTests/Data/ExchangeRateRepositoryTests.swift
+++ b/StockWatch/StockWatchTests/Data/ExchangeRateRepositoryTests.swift
@@ -1,0 +1,71 @@
+//
+//  ExchangeRateRepositoryTests.swift
+//  StockWatchTests
+//
+
+import XCTest
+@testable import StockWatch
+
+final class ExchangeRateRepositoryTests: XCTestCase {
+
+    private var sut: ExchangeRateRepository!
+    private var mockNetworkService: MockNetworkService!
+
+    override func setUp() {
+        super.setUp()
+        mockNetworkService = MockNetworkService()
+        sut = ExchangeRateRepository(networkService: mockNetworkService)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockNetworkService = nil
+        super.tearDown()
+    }
+
+    private func makeQuoteDTO(price: Double) -> YahooFinanceQuoteDTO {
+        YahooFinanceQuoteDTO(
+            chart: .init(
+                result: [
+                    .init(meta: .init(
+                        symbol: "KRW=X",
+                        regularMarketPrice: price,
+                        previousClose: nil,
+                        regularMarketChangePercent: nil,
+                        chartPreviousClose: nil,
+                        shortName: nil,
+                        longName: nil,
+                        currency: nil
+                    ))
+                ],
+                error: nil
+            )
+        )
+    }
+
+    // 단일 통화 조회 시 올바른 환율을 반환하는지 검증
+    func test_fetchRates_withSingleCurrency_returnsRate() async throws {
+        // Given
+        mockNetworkService.stubbedResult = makeQuoteDTO(price: 1380.0)
+
+        // When
+        let result = try await sut.fetchRates(currencies: ["KRW"])
+
+        // Then
+        XCTAssertEqual(result["KRW"], 1380.0)
+    }
+
+    // 네트워크 실패 시 에러 전파
+    func test_fetchRates_whenNetworkFails_throwsError() async {
+        // Given
+        mockNetworkService.stubbedError = NetworkError.networkDisconnected
+
+        // When / Then
+        do {
+            _ = try await sut.fetchRates(currencies: ["KRW"])
+            XCTFail("에러가 전파되어야 한다")
+        } catch {
+            XCTAssertTrue(error is NetworkError)
+        }
+    }
+}

--- a/StockWatch/StockWatchTests/Domain/FetchCandlestickUseCaseTests.swift
+++ b/StockWatch/StockWatchTests/Domain/FetchCandlestickUseCaseTests.swift
@@ -23,6 +23,11 @@ final class MockCandlestickRepository: CandlestickRepositoryProtocol {
         if let error = stubbedError { throw error }
         return stubbedResult ?? CandlestickData(ticker: ticker, candles: [])
     }
+
+    func fetchCandlesticks(ticker: String, range: String, interval: String) async throws -> CandlestickData {
+        if let error = stubbedError { throw error }
+        return stubbedResult ?? CandlestickData(ticker: ticker, candles: [])
+    }
 }
 
 // MARK: - Tests

--- a/StockWatch/StockWatchTests/Domain/FetchExchangeRateUseCaseTests.swift
+++ b/StockWatch/StockWatchTests/Domain/FetchExchangeRateUseCaseTests.swift
@@ -1,0 +1,104 @@
+//
+//  FetchExchangeRateUseCaseTests.swift
+//  StockWatchTests
+//
+
+import XCTest
+@testable import StockWatch
+
+// MARK: - Mock
+
+final class MockExchangeRateRepository: ExchangeRateRepositoryProtocol {
+    var stubbedResult: [String: Double] = [:]
+    var stubbedError: Error?
+    var lastReceivedCurrencies: [String]?
+
+    func fetchRates(currencies: [String]) async throws -> [String: Double] {
+        lastReceivedCurrencies = currencies
+        if let error = stubbedError { throw error }
+        return stubbedResult
+    }
+}
+
+// MARK: - Tests
+
+final class FetchExchangeRateUseCaseTests: XCTestCase {
+
+    private var sut: FetchExchangeRateUseCase!
+    private var mockRepository: MockExchangeRateRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockExchangeRateRepository()
+        sut = FetchExchangeRateUseCase(repository: mockRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // KRW 환율 조회 시 Repository를 호출하고 결과를 반환하는지 검증
+    func test_execute_withKRW_returnsExchangeRate() async throws {
+        // Arrange
+        mockRepository.stubbedResult = ["KRW": 1380.0]
+
+        // Act
+        let result = try await sut.execute(currencies: ["KRW"])
+
+        // Assert
+        XCTAssertEqual(result["KRW"], 1380.0)
+        XCTAssertEqual(result["USD"], 1.0)
+        XCTAssertEqual(mockRepository.lastReceivedCurrencies, ["KRW"])
+    }
+
+    // USD만 요청 시 Repository를 호출하지 않고 1.0을 반환하는지 검증
+    func test_execute_withUSD_returnsOnePointZero() async throws {
+        // Act
+        let result = try await sut.execute(currencies: ["USD"])
+
+        // Assert
+        XCTAssertEqual(result["USD"], 1.0)
+        XCTAssertNil(mockRepository.lastReceivedCurrencies, "USD만 있으면 Repository를 호출하지 않아야 한다")
+    }
+
+    // 빈 배열 입력 시 USD만 포함된 딕셔너리를 반환하는지 검증
+    func test_execute_withEmptyCurrencies_returnsOnlyUSD() async throws {
+        // Act
+        let result = try await sut.execute(currencies: [])
+
+        // Assert
+        XCTAssertEqual(result, ["USD": 1.0])
+        XCTAssertNil(mockRepository.lastReceivedCurrencies)
+    }
+
+    // Repository 에러가 올바르게 전파되는지 검증
+    func test_execute_whenRepositoryThrows_propagatesError() async {
+        // Arrange
+        mockRepository.stubbedError = NetworkError.serverError
+
+        // Act / Assert
+        do {
+            _ = try await sut.execute(currencies: ["KRW"])
+            XCTFail("에러가 전파되어야 한다")
+        } catch {
+            XCTAssertTrue(error is NetworkError)
+        }
+    }
+
+    // 여러 통화 요청 시 USD는 자동 포함되고 나머지만 Repository에 전달하는지 검증
+    func test_execute_withMixedCurrencies_filtersUSDFromRepositoryCall() async throws {
+        // Arrange
+        mockRepository.stubbedResult = ["KRW": 1380.0, "JPY": 155.0]
+
+        // Act
+        let result = try await sut.execute(currencies: ["USD", "KRW", "JPY"])
+
+        // Assert
+        XCTAssertEqual(result["USD"], 1.0)
+        XCTAssertEqual(result["KRW"], 1380.0)
+        XCTAssertEqual(result["JPY"], 155.0)
+        XCTAssertEqual(Set(mockRepository.lastReceivedCurrencies ?? []), Set(["KRW", "JPY"]))
+    }
+}

--- a/StockWatch/StockWatchTests/Domain/ManageWatchListGroupUseCaseTests.swift
+++ b/StockWatch/StockWatchTests/Domain/ManageWatchListGroupUseCaseTests.swift
@@ -134,6 +134,8 @@ final class ManageWatchListGroupUseCaseTests: XCTestCase {
         try await sut.deleteGroup(id: group.id)
         let remaining = await sut.fetchGroups()
         XCTAssertTrue(remaining.isEmpty)
+    }
+
     // MARK: - Validation
 
     @MainActor

--- a/StockWatch/StockWatchTests/Presentation/StockDetailStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/StockDetailStoreTests.swift
@@ -64,6 +64,7 @@ final class MockFetchStockDetailUseCase: FetchStockDetailUseCaseProtocol {
     }
 }
 
+@MainActor
 final class MockToggleFavoriteUseCase: ToggleFavoriteUseCaseProtocol {
     var stubbedResult: Bool = false
     var stubbedError: Error?

--- a/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
@@ -480,6 +480,46 @@ final class WatchListStoreTests: XCTestCase {
         XCTAssertEqual(sut.state.sortDirection, .ascending)
     }
 
+    func test_action_toggleSort_changePercent_cyclesDescAscNone() {
+        // 초기: 정렬 없음
+        XCTAssertNil(sut.state.sortCriteria)
+
+        // 1탭: 내림차순 (등락률은 내림차순부터 시작)
+        sut.action(.toggleSort(.changePercent))
+        XCTAssertEqual(sut.state.sortCriteria, .changePercent)
+        XCTAssertEqual(sut.state.sortDirection, .descending)
+
+        // 2탭: 오름차순
+        sut.action(.toggleSort(.changePercent))
+        XCTAssertEqual(sut.state.sortCriteria, .changePercent)
+        XCTAssertEqual(sut.state.sortDirection, .ascending)
+
+        // 3탭: 해제
+        sut.action(.toggleSort(.changePercent))
+        XCTAssertNil(sut.state.sortCriteria)
+        XCTAssertEqual(sut.state.sortDirection, .ascending)
+    }
+
+    func test_action_toggleSort_switchToChangePercent_startsDescending() {
+        // name 오름차순 상태에서 changePercent로 전환 → 내림차순
+        sut.action(.toggleSort(.name))
+        XCTAssertEqual(sut.state.sortCriteria, .name)
+
+        sut.action(.toggleSort(.changePercent))
+        XCTAssertEqual(sut.state.sortCriteria, .changePercent)
+        XCTAssertEqual(sut.state.sortDirection, .descending)
+    }
+
+    func test_action_toggleSort_switchFromChangePercent_startsAscending() {
+        // changePercent 정렬 중에 name으로 전환 → 오름차순
+        sut.action(.toggleSort(.changePercent))
+        XCTAssertEqual(sut.state.sortCriteria, .changePercent)
+
+        sut.action(.toggleSort(.name))
+        XCTAssertEqual(sut.state.sortCriteria, .name)
+        XCTAssertEqual(sut.state.sortDirection, .ascending)
+    }
+
     func test_sortedFavorites_byNameAsc_sortsAlphabetically() {
         // Arrange — companyName으로 정렬 (KoreanStockDictionary는 테스트에서 비어있으므로 fallback)
         let items = [
@@ -540,8 +580,7 @@ final class WatchListStoreTests: XCTestCase {
             "TSLA": StockQuote(ticker: "TSLA", currentPrice: 70.0, priceChangePercent: -2.0, currency: "USD")
         ]
         sut = makeStore(state: state)
-        sut.action(.toggleSort(.changePercent)) // asc
-        sut.action(.toggleSort(.changePercent)) // desc
+        sut.action(.toggleSort(.changePercent)) // desc (등락률은 첫 탭이 내림차순)
 
         let sorted = sut.sortedFavorites
         XCTAssertEqual(sorted[0].ticker, "AAPL") // 1.0 > -2.0

--- a/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
@@ -752,4 +752,80 @@ final class WatchListStoreTests: XCTestCase {
         XCTAssertEqual(sut.state.dbGroups.count, 1)
         XCTAssertEqual(sut.state.selectedGroupIndex, 0)
     }
+
+    // MARK: - sortedFavorites 마켓 필터
+
+    func test_sortedFavorites_domesticFilter_returnsOnlyKoreanTickers() {
+        // Arrange
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "035720.KQ", companyName: "카카오", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+
+        // Act
+        sut.action(.selectMarketFilter(.domestic))
+        let result = sut.sortedFavorites
+
+        // Assert
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.ticker.isDomesticTicker })
+        XCTAssertEqual(result.map(\.ticker).sorted(), ["005930.KS", "035720.KQ"])
+    }
+
+    func test_sortedFavorites_overseasFilter_excludesKoreanTickers() {
+        // Arrange
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+
+        // Act
+        sut.action(.selectMarketFilter(.overseas))
+        let result = sut.sortedFavorites
+
+        // Assert
+        XCTAssertEqual(result.count, 2)
+        XCTAssertFalse(result.contains { $0.ticker.isDomesticTicker })
+        XCTAssertEqual(result.map(\.ticker).sorted(), ["AAPL", "TSLA"])
+    }
+
+    func test_sortedFavorites_allFilter_returnsAllFavorites() {
+        // Arrange
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+
+        // Act
+        sut.action(.selectMarketFilter(.all))
+        let result = sut.sortedFavorites
+
+        // Assert
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func test_sortedFavorites_domesticFilter_withSort_appliesFilterThenSort() {
+        // Arrange
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "000660.KS", companyName: "SK하이닉스", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+        sut.action(.selectMarketFilter(.domestic))
+        sut.action(.toggleSort(.name)) // ascending
+
+        // Act
+        let result = sut.sortedFavorites
+
+        // Assert — 국내 2개만 이름 오름차순 정렬 (KoreanStockDictionary fallback → companyName)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertFalse(result.contains { $0.ticker == "AAPL" })
+    }
 }

--- a/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
@@ -718,6 +718,23 @@ final class WatchListStoreTests: XCTestCase {
 
     // MARK: - deleteGroup (continued)
 
+    func test_action_selectMarketFilter_updatesState() {
+        // Arrange
+        XCTAssertEqual(sut.state.marketFilter, .all)
+
+        // Act
+        sut.action(.selectMarketFilter(.domestic))
+
+        // Assert
+        XCTAssertEqual(sut.state.marketFilter, .domestic)
+
+        // Act — 해외주식으로 변경
+        sut.action(.selectMarketFilter(.overseas))
+
+        // Assert
+        XCTAssertEqual(sut.state.marketFilter, .overseas)
+    }
+
     func test_action_deleteGroup_currentGroupDeleted_selectsFirstRemaining() async {
         // Arrange
         let group1 = WatchListGroup(id: UUID(), name: "그룹1", createdAt: Date())

--- a/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
@@ -42,6 +42,15 @@ final class MockAddFavoriteToGroupUseCase: AddFavoriteToGroupUseCaseProtocol {
     func execute(ticker: String, companyName: String, logoURL: String, groupId: UUID) async throws {}
 }
 
+final class MockFetchSparklineUseCase: FetchSparklineUseCaseProtocol {
+    var stubbedResult: SparklineData?
+    var stubbedError: Error?
+    func execute(ticker: String) async throws -> SparklineData {
+        if let error = stubbedError { throw error }
+        return stubbedResult ?? SparklineData(ticker: ticker, closePrices: [])
+    }
+}
+
 final class MockFetchStockQuoteUseCase: FetchStockQuoteUseCaseProtocol {
     var stubbedResult: StockQuote = StockQuote(ticker: "", currentPrice: 0, priceChangePercent: 0, currency: "USD")
     var stubbedError: Error?
@@ -94,6 +103,9 @@ final class WatchListStoreTests: XCTestCase {
             fetchFavoritesByGroupUseCase: mockFetchByGroupUseCase,
             addFavoriteToGroupUseCase: MockAddFavoriteToGroupUseCase(),
             fetchStockQuoteUseCase: mockFetchStockQuoteUseCase,
+            fetchGroupIdsForTickerUseCase: MockFetchGroupIdsForTickerUseCase(),
+            updateFavoriteGroupsUseCase: MockUpdateFavoriteGroupsUseCase(),
+            fetchSparklineUseCase: MockFetchSparklineUseCase(),
             state: state
         )
     }

--- a/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
@@ -447,6 +447,139 @@ final class WatchListStoreTests: XCTestCase {
         XCTAssertNil(sut.state.draggedGroupId)
     }
 
+    // MARK: - toggleSort
+
+    func test_action_toggleSort_name_cyclesNoneAscDescNone() {
+        // 초기: 정렬 없음
+        XCTAssertNil(sut.state.sortCriteria)
+
+        // 1탭: 오름차순
+        sut.action(.toggleSort(.name))
+        XCTAssertEqual(sut.state.sortCriteria, .name)
+        XCTAssertEqual(sut.state.sortDirection, .ascending)
+
+        // 2탭: 내림차순
+        sut.action(.toggleSort(.name))
+        XCTAssertEqual(sut.state.sortCriteria, .name)
+        XCTAssertEqual(sut.state.sortDirection, .descending)
+
+        // 3탭: 해제
+        sut.action(.toggleSort(.name))
+        XCTAssertNil(sut.state.sortCriteria)
+        XCTAssertEqual(sut.state.sortDirection, .ascending)
+    }
+
+    func test_action_toggleSort_switchColumn_resetsToAsc() {
+        // name 오름차순
+        sut.action(.toggleSort(.name))
+        XCTAssertEqual(sut.state.sortCriteria, .name)
+
+        // price로 전환 → 오름차순
+        sut.action(.toggleSort(.price))
+        XCTAssertEqual(sut.state.sortCriteria, .price)
+        XCTAssertEqual(sut.state.sortDirection, .ascending)
+    }
+
+    func test_sortedFavorites_byNameAsc_sortsAlphabetically() {
+        // Arrange — companyName으로 정렬 (KoreanStockDictionary는 테스트에서 비어있으므로 fallback)
+        let items = [
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+        sut.action(.toggleSort(.name)) // ascending
+
+        // Act
+        let sorted = sut.sortedFavorites
+
+        // Assert
+        XCTAssertEqual(sorted[0].ticker, "AAPL")
+        XCTAssertEqual(sorted[1].ticker, "TSLA")
+    }
+
+    func test_sortedFavorites_byNameDesc_sortsReverse() {
+        let items = [
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+        sut.action(.toggleSort(.name)) // asc
+        sut.action(.toggleSort(.name)) // desc
+
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "TSLA")
+        XCTAssertEqual(sorted[1].ticker, "AAPL")
+    }
+
+    func test_sortedFavorites_byPriceAsc_sortsByCurrentPrice() {
+        let items = [
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "AAPL": StockQuote(ticker: "AAPL", currentPrice: 150.0, priceChangePercent: 1.0, currency: "USD"),
+            "TSLA": StockQuote(ticker: "TSLA", currentPrice: 70.0, priceChangePercent: -2.0, currency: "USD")
+        ]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.price)) // ascending
+
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "TSLA") // 70 < 150
+        XCTAssertEqual(sorted[1].ticker, "AAPL")
+    }
+
+    func test_sortedFavorites_byChangePercentDesc_sortsByChangePercent() {
+        let items = [
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "AAPL": StockQuote(ticker: "AAPL", currentPrice: 150.0, priceChangePercent: 1.0, currency: "USD"),
+            "TSLA": StockQuote(ticker: "TSLA", currentPrice: 70.0, priceChangePercent: -2.0, currency: "USD")
+        ]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.changePercent)) // asc
+        sut.action(.toggleSort(.changePercent)) // desc
+
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "AAPL") // 1.0 > -2.0
+        XCTAssertEqual(sorted[1].ticker, "TSLA")
+    }
+
+    func test_sortedFavorites_none_returnsOriginalOrder() {
+        let items = [
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        sut = makeStore(state: WatchListState(favorites: items))
+
+        // 정렬 없음 — 원본 순서
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "TSLA")
+        XCTAssertEqual(sorted[1].ticker, "AAPL")
+    }
+
+    func test_sortedFavorites_byPrice_missingPriceData_placedAtEnd() {
+        let items = [
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "TSLA": StockQuote(ticker: "TSLA", currentPrice: 70.0, priceChangePercent: -2.0, currency: "USD")
+        ]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.price)) // ascending
+
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "TSLA") // has price
+        XCTAssertEqual(sorted[1].ticker, "AAPL") // no price → end
+    }
+
+    // MARK: - deleteGroup (continued)
+
     func test_action_deleteGroup_currentGroupDeleted_selectsFirstRemaining() async {
         // Arrange
         let group1 = WatchListGroup(id: UUID(), name: "그룹1", createdAt: Date())

--- a/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
+++ b/StockWatch/StockWatchTests/Presentation/WatchListStoreTests.swift
@@ -60,6 +60,15 @@ final class MockFetchStockQuoteUseCase: FetchStockQuoteUseCaseProtocol {
     }
 }
 
+final class MockFetchExchangeRateUseCase: FetchExchangeRateUseCaseProtocol {
+    var stubbedResult: [String: Double] = ["USD": 1.0]
+    var stubbedError: Error?
+    func execute(currencies: [String]) async throws -> [String: Double] {
+        if let error = stubbedError { throw error }
+        return stubbedResult
+    }
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -106,6 +115,7 @@ final class WatchListStoreTests: XCTestCase {
             fetchGroupIdsForTickerUseCase: MockFetchGroupIdsForTickerUseCase(),
             updateFavoriteGroupsUseCase: MockUpdateFavoriteGroupsUseCase(),
             fetchSparklineUseCase: MockFetchSparklineUseCase(),
+            fetchExchangeRateUseCase: MockFetchExchangeRateUseCase(),
             state: state
         )
     }
@@ -175,7 +185,7 @@ final class WatchListStoreTests: XCTestCase {
 
         // Act
         sut.action(.removeFavorite(ticker: "AAPL"))
-        for _ in 0..<4 { await Task.yield() }
+        for _ in 0..<8 { await Task.yield() }
 
         // Assert (에러 시 롤백)
         XCTAssertEqual(sut.state.favorites.count, 1)
@@ -615,6 +625,95 @@ final class WatchListStoreTests: XCTestCase {
         let sorted = sut.sortedFavorites
         XCTAssertEqual(sorted[0].ticker, "TSLA") // has price
         XCTAssertEqual(sorted[1].ticker, "AAPL") // no price → end
+    }
+
+    // MARK: - 환율 기반 현재가 정렬
+
+    // KRW 2880원 vs USD 280달러 → USD 환산 시 280 > ~2.09 → 280이 더 높아야 함
+    func test_sortedFavorites_byPrice_comparesInUSD() {
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "005930.KS": StockQuote(ticker: "005930.KS", currentPrice: 2880.0, priceChangePercent: 0.5, currency: "KRW"),
+            "AAPL": StockQuote(ticker: "AAPL", currentPrice: 280.0, priceChangePercent: 1.0, currency: "USD")
+        ]
+        state.exchangeRates = ["KRW": 1380.0, "USD": 1.0]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.price)) // ascending
+
+        let sorted = sut.sortedFavorites
+        // 삼성전자: 2880 / 1380 ≈ 2.09 USD < AAPL: 280 USD
+        XCTAssertEqual(sorted[0].ticker, "005930.KS")
+        XCTAssertEqual(sorted[1].ticker, "AAPL")
+    }
+
+    // KRW, USD, JPY 혼합 정렬
+    func test_sortedFavorites_byPrice_withMixedCurrencies_sortsCorrectly() {
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "7203.T", companyName: "Toyota", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "005930.KS": StockQuote(ticker: "005930.KS", currentPrice: 70000.0, priceChangePercent: 0.5, currency: "KRW"),
+            "AAPL": StockQuote(ticker: "AAPL", currentPrice: 200.0, priceChangePercent: 1.0, currency: "USD"),
+            "7203.T": StockQuote(ticker: "7203.T", currentPrice: 3000.0, priceChangePercent: -0.5, currency: "JPY")
+        ]
+        // KRW: 70000/1380 ≈ 50.72 USD, JPY: 3000/155 ≈ 19.35 USD, AAPL: 200 USD
+        state.exchangeRates = ["KRW": 1380.0, "USD": 1.0, "JPY": 155.0]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.price)) // ascending
+
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "7203.T")    // 19.35 USD
+        XCTAssertEqual(sorted[1].ticker, "005930.KS")  // 50.72 USD
+        XCTAssertEqual(sorted[2].ticker, "AAPL")        // 200 USD
+    }
+
+    // 환율 데이터 없으면 raw price fallback
+    func test_sortedFavorites_byPrice_withoutExchangeRate_fallsBackToRawPrice() {
+        let items = [
+            FavoriteItem(ticker: "005930.KS", companyName: "삼성전자", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "005930.KS": StockQuote(ticker: "005930.KS", currentPrice: 2880.0, priceChangePercent: 0.5, currency: "KRW"),
+            "AAPL": StockQuote(ticker: "AAPL", currentPrice: 280.0, priceChangePercent: 1.0, currency: "USD")
+        ]
+        // exchangeRates 비어있음 → fallback: raw price 비교
+        state.exchangeRates = [:]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.price)) // ascending
+
+        let sorted = sut.sortedFavorites
+        // fallback: 280 < 2880
+        XCTAssertEqual(sorted[0].ticker, "AAPL")
+        XCTAssertEqual(sorted[1].ticker, "005930.KS")
+    }
+
+    // 같은 통화끼리는 직접 비교 (환율 변환이 동일하므로 결과 동일)
+    func test_sortedFavorites_byPrice_sameCurrency_comparesDirectly() {
+        let items = [
+            FavoriteItem(ticker: "AAPL", companyName: "Apple", addedAt: Date(), logoURL: "", groupIds: []),
+            FavoriteItem(ticker: "TSLA", companyName: "Tesla", addedAt: Date(), logoURL: "", groupIds: [])
+        ]
+        var state = WatchListState(favorites: items)
+        state.priceData = [
+            "AAPL": StockQuote(ticker: "AAPL", currentPrice: 200.0, priceChangePercent: 1.0, currency: "USD"),
+            "TSLA": StockQuote(ticker: "TSLA", currentPrice: 300.0, priceChangePercent: -1.0, currency: "USD")
+        ]
+        state.exchangeRates = ["USD": 1.0]
+        sut = makeStore(state: state)
+        sut.action(.toggleSort(.price)) // ascending
+
+        let sorted = sut.sortedFavorites
+        XCTAssertEqual(sorted[0].ticker, "AAPL")  // 200
+        XCTAssertEqual(sorted[1].ticker, "TSLA")   // 300
     }
 
     // MARK: - deleteGroup (continued)


### PR DESCRIPTION
# 📌 이슈번호
- #68 

# 📌 구현/추가 사항
- [x] 스파크 차트
- [x] 종목명(가나다 오름/내림차순)
- [x] 현재가(오름/내림차순)
- [x] 등락률(오름/내림차순)
- [x] 전체/국내/해외 주식 하단 필터 버튼
- [x] 원/엔화/달러가 같이 있을 경우 현재가 필터링 문제 해결(2805원이 288달러보다 크다고 판단됨)