### PR TITLE
[Fix] 워치리스트 현재가, 등락 정렬 버튼 위치 수정

### DIFF
--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -745,7 +745,7 @@ private struct WatchListSortHeaderView: View {
             }
             Color.clear.frame(width: 26)
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 20)
         .padding(.vertical, 8)
     }
 
@@ -818,6 +818,7 @@ private struct WatchListStockRow: View {
                 .font(.pretendard(size: 18))
         }
         .buttonStyle(.plain)
+        .frame(width: 26)
     }
 
     @ViewBuilder

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -732,12 +732,18 @@ private struct WatchListSortHeaderView: View {
     let onToggle: (WatchListSortCriteria) -> Void
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 8) {
+            // logo(44) + spacing(8) = 52pt offset → 종목명 leading에 정렬
             sortButton(label: sortCriteria == .name ? "가나다 순" : "종목", criteria: .name)
+                .padding(.leading, 56)
             Spacer()
-            sortButton(label: "현재가", criteria: .price)
-            Spacer()
-            sortButton(label: "등락", criteria: .changePercent)
+            HStack(spacing: 6) {
+                sortButton(label: "현재가", criteria: .price)
+                    .frame(width: 52, alignment: .trailing)
+                sortButton(label: "등락", criteria: .changePercent)
+                    .frame(width: 52, alignment: .trailing)
+            }
+            Color.clear.frame(width: 26)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
@@ -783,16 +789,21 @@ private struct WatchListStockRow: View {
     var body: some View {
         HStack(spacing: 8) {
             logoView
+                .padding(.trailing, 4)   // 심볼↔종목명 간격 추가
             nameColumn
                 .frame(minWidth: 80, maxWidth: 120, alignment: .leading)
-            Spacer(minLength: 8)
+            Spacer(minLength: 0)         // 종목명↔스파크라인 간격 축소
             sparklineColumn
             Spacer(minLength: 8)
-            priceColumn
-                .frame(width: 90, alignment: .trailing)
+            HStack(spacing: 6) {
+                currentPriceColumn
+                    .frame(width: 52, alignment: .trailing)
+                changePercentColumn
+                    .frame(width: 52, alignment: .trailing)
+            }
             heartButton
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 20)        // 좌우 여백 확대
         .padding(.vertical, 12)
         .contentShape(Rectangle())
         .onTapGesture(perform: onTap)
@@ -858,16 +869,26 @@ private struct WatchListStockRow: View {
         }
     }
 
-    private var priceColumn: some View {
+    private var currentPriceColumn: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            if let data = quoteData {
+                Text(formattedPrice(data.currentPrice, currency: data.currency))
+                    .font(.pretendardMedium(size: 15))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+        }
+    }
+
+    private var changePercentColumn: some View {
         VStack(alignment: .trailing, spacing: 2) {
             if let data = quoteData {
                 let positive = data.priceChangePercent >= 0
                 Text(String(format: "%@%.2f%%", positive ? "+" : "", data.priceChangePercent))
                     .font(.pretendardMedium(size: 15))
                     .foregroundStyle(positive ? Color(hex: "#ef5350") : Color(hex: "#1976d2"))
-                Text(formattedPrice(data.currentPrice, currency: data.currency))
-                    .font(.pretendardCaption)
-                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
         }
     }

--- a/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
+++ b/StockWatch/StockWatch/Presentation/Tab/WatchList/View/WatchListView.swift
@@ -20,7 +20,7 @@ struct WatchListView: View {
 // MARK: - Content View
 
 private struct WatchListContentView: View {
-
+    
     @StateObject private var store: WatchListStore
     @State private var isShowingGroupManageModal = false
     @State private var isShowingAddStock = false
@@ -726,24 +726,43 @@ private struct WatchListGroupManageModalView: View {
 
 // MARK: - Sort Header
 
+// MARK: - Layout Constants
+
+private enum WatchListLayout {
+    static let logoSize: CGFloat = 44
+    static let logoTrailingPad: CGFloat = 4
+    static let rowHSpacing: CGFloat = 8
+    /// 종목명 leading offset = logo(44) + logoPad(4) + hStackSpacing(8)
+    static let nameLeadingOffset: CGFloat = logoSize + logoTrailingPad + rowHSpacing
+    static let sparklineWidth: CGFloat = 60
+    static let sparklineHeight: CGFloat = 32
+    static let priceColumnWidth: CGFloat = 52
+    static let changeColumnWidth: CGFloat = 52
+    static let columnSpacing: CGFloat = 6
+    static let heartWidth: CGFloat = 26
+    static let sparklineTrailingPad: CGFloat = 16
+}
+
 private struct WatchListSortHeaderView: View {
     let sortCriteria: WatchListSortCriteria?
     let sortDirection: WatchListSortDirection
     let onToggle: (WatchListSortCriteria) -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            // logo(44) + spacing(8) = 52pt offset → 종목명 leading에 정렬
+        HStack(spacing: 0) {
             sortButton(label: sortCriteria == .name ? "가나다 순" : "종목", criteria: .name)
-                .padding(.leading, 56)
-            Spacer()
-            HStack(spacing: 6) {
+                .padding(.leading, WatchListLayout.nameLeadingOffset)
+            Spacer(minLength: 0)
+            // sparkline 자리 확보 (행과 동일하게)
+            Color.clear.frame(width: WatchListLayout.sparklineWidth)
+                .padding(.trailing, WatchListLayout.sparklineTrailingPad)
+            HStack(spacing: WatchListLayout.columnSpacing) {
                 sortButton(label: "현재가", criteria: .price)
-                    .frame(width: 52, alignment: .trailing)
+                    .frame(width: WatchListLayout.priceColumnWidth, alignment: .leading)
                 sortButton(label: "등락", criteria: .changePercent)
-                    .frame(width: 52, alignment: .trailing)
+                    .frame(width: WatchListLayout.changeColumnWidth, alignment: .leading)
             }
-            Color.clear.frame(width: 26)
+            Color.clear.frame(width: WatchListLayout.heartWidth)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 8)
@@ -787,23 +806,23 @@ private struct WatchListStockRow: View {
     let onRemove: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 0) {
             logoView
-                .padding(.trailing, 4)   // 심볼↔종목명 간격 추가
+                .padding(.trailing, WatchListLayout.logoTrailingPad + WatchListLayout.rowHSpacing)
             nameColumn
-                .frame(minWidth: 80, maxWidth: 120, alignment: .leading)
-            Spacer(minLength: 0)         // 종목명↔스파크라인 간격 축소
+            Spacer(minLength: 0)
             sparklineColumn
-            Spacer(minLength: 8)
-            HStack(spacing: 6) {
+                .frame(width: WatchListLayout.sparklineWidth, height: WatchListLayout.sparklineHeight)
+                .padding(.trailing, WatchListLayout.sparklineTrailingPad)
+            HStack(spacing: WatchListLayout.columnSpacing) {
                 currentPriceColumn
-                    .frame(width: 52, alignment: .trailing)
+                    .frame(width: WatchListLayout.priceColumnWidth, alignment: .trailing)
                 changePercentColumn
-                    .frame(width: 52, alignment: .trailing)
+                    .frame(width: WatchListLayout.changeColumnWidth, alignment: .trailing)
             }
             heartButton
         }
-        .padding(.horizontal, 20)        // 좌우 여백 확대
+        .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .contentShape(Rectangle())
         .onTapGesture(perform: onTap)
@@ -866,7 +885,8 @@ private struct WatchListStockRow: View {
                 isPositive: (quoteData?.priceChangePercent ?? 0) >= 0,
                 currentPrice: quoteData?.currentPrice
             )
-            .frame(width: 60, height: 32)
+        } else {
+            Color.clear
         }
     }
 


### PR DESCRIPTION
# 📌 이슈번호
- #95 

# 📌 구현/추가 사항
- 종목명, 현재가, 등락률 정렬 버튼 위치를 아래의 본문 열과 위치를 일치시킴